### PR TITLE
Fix for relative paths on 1.9 for the chat example app

### DIFF
--- a/examples/app/chat/start.rb
+++ b/examples/app/chat/start.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'ramaze'
 
-require 'model/history'
-require 'model/message'
+require __DIR__ 'model/history'
+require __DIR__ 'model/message'
 
 class ChatRoom < Ramaze::Controller
   map '/'


### PR DESCRIPTION
Since we keep 1.8 support, I've used __DIR__ instead of require_relative.
