### PR TITLE
Doc changes

### DIFF
--- a/guide/general/helpers.md
+++ b/guide/general/helpers.md
@@ -77,8 +77,8 @@ load all helpers the Ramaze way.
 
 ## Innate Helpers
 
-Note that you may also find some popular helpers that are used by default in 
-Ramaze under the Innate project.
+Note that you may also find some popular helpers, that are used by default in 
+Ramaze, under the Innate project.
 
 * {Innate::Helper::Aspect}: provides before/after wrappers for actions.
 * {Innate::Helper::CGI}: gives shortcuts to some CGI methods.

--- a/guide/general/middlewares.md
+++ b/guide/general/middlewares.md
@@ -106,3 +106,14 @@ the existing ones you either have to read-in each one using
 ``Innate#MiddlewareCompiler#middlewares`` and re-add it to the newly created
 middleware stack or simply copy (lets say in your app.rb) what has been setup
 inside ``lib/ramaze.rb``.
+
+	current_mw = Ramaze.middleware(:dev).middlewares
+	Ramaze.middleware! :dev do |mode|
+  	  current_mw.each do |mw|
+	    mode.use(mw[0],*mw[1], &mw[2]) # middleware, args, block
+	  end
+	
+	  mode.use(Banlist)
+	  mode.run(Ramaze::AppMap)
+	end
+	


### PR DESCRIPTION
Explains how to re-use current middlewares stack with own middleware.
References the default Innate helpers from the helpers docs section in order to help readers find them easily.
