### PR TITLE
Adds sid regenration on user logout

### DIFF
--- a/lib/ramaze/helper/user.rb
+++ b/lib/ramaze/helper/user.rb
@@ -249,6 +249,7 @@ module Ramaze
         def _logout
           (_persistence || {}).clear
           Current.request.env['ramaze.helper.user'] = nil
+          Current.session.resid!
         end
 
         ##

--- a/spec/ramaze/helper/user.rb
+++ b/spec/ramaze/helper/user.rb
@@ -33,6 +33,10 @@ class SpecUserHelper < Ramaze::Controller
   def profile
     user.profile
   end
+
+  def sid
+    session.sid
+  end
 end
 
 Arthur = {
@@ -74,4 +78,12 @@ describe Ramaze::Helper::UserHelper do
     get('/logout').status.should == 200
     get('/callback/status').body.should == 'no'
   end
+
+  should 'change sid after logout' do
+    get('/login?name=arthur&password=42').body.should == 'logged in'
+    oldsid = get('/sid').body
+    get('/logout').status.should == 200
+    get('/sid').body.should.not == oldsid
+  end
 end
+


### PR DESCRIPTION
When Ramaze::Helper::UserHelper#_logout is called, the session.sid is
not regenerated. This can confuse session tracking libraries that rely
on session IDs.
This patch forces _logout to regenerate a sid.
A test is included to ensure sid rotation at logout.
