### PR TITLE
Makes gravatar nil-proof

### DIFF
--- a/lib/ramaze/helper/gravatar.rb
+++ b/lib/ramaze/helper/gravatar.rb
@@ -57,6 +57,8 @@ module Ramaze
       # @author manveru
       #
       def gravatar(email, opts = {})
+        # let's make email nil-proof so developer doesn't have to check
+        email ||= ""
         uri = URI("http://www.gravatar.com/")
         ext = opts[:ext]
         uri.path = "/avatar/#{Digest::MD5.hexdigest(email.to_str)}#{ext}"

--- a/spec/ramaze/helper/gravatar.rb
+++ b/spec/ramaze/helper/gravatar.rb
@@ -18,6 +18,10 @@ describe Ramaze::Helper::Gravatar do
     gravatar(@email).should == uri
   end
 
+  it 'handles nil emails properly and turns it into a hashed part of the uri' do
+    gravatar(nil).should == URI("http://www.gravatar.com/avatar/d41d8cd98f00b204e9800998ecf8427e")
+  end
+
   it 'takes :size option' do
     gravatar(@email, :size => 100).should == uri('?size=100')
   end


### PR DESCRIPTION
Ramaze::Helper::Gravatar#gravatar method will happpily accept a nil
argument. This releases the developper from checking it the email is
valid. In case of nil email, gravatar.com will return a default gravatar
image (until a MD5 collision happens).
