### PR TITLE
Fixes issue #43

### DIFF
--- a/lib/ramaze/helper/upload.rb
+++ b/lib/ramaze/helper/upload.rb
@@ -493,6 +493,8 @@ module Ramaze
           # Update the realfile property, indicating that the file has been
           # saved
           @realfile = File.new(path)
+          # But no need to keep it open
+          @realfile.close
 
           # If the unlink_tempfile option is set to true, delete the temporary
           # file created by Rack

--- a/spec/ramaze/helper/upload.rb
+++ b/spec/ramaze/helper/upload.rb
@@ -145,5 +145,6 @@ describe('Ramaze::Helper::Upload::UploadedFile') do
     file.save('/tmp/ramaze_uploads/text_1.txt')
 
     file.path.nil?.should === false
+    file.instance_variable_get("@realfile").closed?.should === true
   end
 end


### PR DESCRIPTION
Closes uploaded file, since leaving it opened doesn't seem to be
required, and it might lead to issues on Win32.
Added spec to check that file has been closed.
