### PR TITLE
Ramaze::Logger::Syslog should escape printf % sequences before handing the message to ::Syslog

### DIFF
--- a/lib/ramaze/log/syslog.rb
+++ b/lib/ramaze/log/syslog.rb
@@ -38,8 +38,7 @@ module Ramaze
       # Just sends all messages received to ::Syslog
       # We simply return if the log was closed for some reason, this behavior
       # was copied from Informer.  We do not handle levels here. This will
-      # be done by te syslog daemon based on it's configuration.
-      #
+      # be done by the syslog daemon based on it's configuration.
       def log(tag, *messages)
         return if !::Syslog.opened?
         tag = tag.to_sym
@@ -48,6 +47,7 @@ module Ramaze
           tag = ALIASES[tag]
         end
 
+        messages = messages.map {|m| m.gsub(/(%[^m])/,'%\1')}
         ::Syslog.send(tag, *messages)
       end
 

--- a/spec/ramaze/log/syslog.rb
+++ b/spec/ramaze/log/syslog.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #          Copyright (c) 2008 rob@rebeltechnologies.nl
 # All files in this distribution are subject to the terms of the MIT license.
 
@@ -75,5 +76,8 @@ describe 'Syslog' do
 	end
 	it 'should handle error' do
 		test_log_msg :direct, :error, 'Hello Error World!'
+	end
+	it 'should escape % sequences' do
+		test_log_msg :direct, :info, "Hello Cruel |évil| 戈 REAL %s World"
 	end
 end


### PR DESCRIPTION
[One more time with feeling]

If a log message happens to contain a percent escape sequence (valid or not) it is passed as is to ::Syslog which passes it down to syslog(3) which blows up for lack of arguments.

Side note: I initially added support for the special %m sequence for syslog(3) but found out that Ruby blew up on it too. I filed a bug at Ruby Redmine (http://bugs.ruby-lang.org/issues/6726) and they're planning to remove the intended support for this sequence.
