### PR TITLE
Minor change in slim spec to request template with variable.

### DIFF
--- a/spec/ramaze/view/slim.rb
+++ b/spec/ramaze/view/slim.rb
@@ -39,7 +39,7 @@ describe 'Ramaze::View::Slim' do
   end
 
   should 'render an external template with variables' do
-    got = get('/external')
+    got = get('/external_vars')
 
     got.status.should          == 200
     got['Content-Type'].should == 'text/html'


### PR DESCRIPTION
Request '/external_vars' to use the '@name' variable along with the 'external_vars.slim' file.

Signed-off-by: Shan Huang shan.huang@me.com
