### PR TITLE
add Moneta cache store

### DIFF
--- a/lib/ramaze/cache.rb
+++ b/lib/ramaze/cache.rb
@@ -12,6 +12,7 @@ module Ramaze
     autoload :MemCache,      'ramaze/cache/memcache'
     autoload :Sequel,        'ramaze/cache/sequel'
     autoload :Redis,         'ramaze/cache/redis'
+    autoload :Moneta,        'ramaze/cache/moneta'
 
     ##
     # Overwrites {Innate::Cache#initialize} to make cache classes application

--- a/lib/ramaze/cache/moneta.rb
+++ b/lib/ramaze/cache/moneta.rb
@@ -1,0 +1,143 @@
+require 'moneta'
+
+module Ramaze
+  class Cache
+    ##
+    # The Moneta cache is a cache driver for Moneta (http://github.com/minad/moneta). Moneta is a
+    # unified interface to key/value stores.
+    #
+    # The usage of this cache is very similar to the Memcache driver. You load
+    # it by simply specifying the class:
+    #
+    #     Ramaze::Cache.options.session = Ramaze::Cache::Moneta
+    #
+    # If you want to specify custom options you can do so by calling {.using} on
+    # the class:
+    #
+    #     Ramaze::Cache.options.session = Ramaze::Cache::Moneta.using(...)
+    #
+    # @example Configuring the Moneta backend
+    #  Ramaze::Cache.options.names.push(:moneta)
+    #  Ramaze::Cache.options.moneta = Ramaze::Cache::Moneta.using(
+    #    :adapter => :File,
+    #    :dir => './ramaze-cache'
+    #  )
+    #
+    # @author Daniel Mendler
+    #
+    class Moneta
+      include Cache::API
+      include Innate::Traited
+
+      # Hash containing all the default options to use when no custom ones are
+      # specified in .using().
+      trait :default => {
+        :expires_in => 604800,
+        :adapter => :Memory,
+      }
+
+      # Hash containing all the default options merged with the user specified
+      # ones.
+      attr_accessor :options
+
+      class << self
+        attr_accessor :options
+
+        ##
+        # Creates a new instance of the cache class and merges the default
+        # options with the custom ones.
+        #
+        # Using this method you can specify custom options for various caches.
+        # For example, the Moneta cache for your sessions could be located at
+        # server #1 while a custom cache is located on server #2.
+        #
+        # @author Daniel Mendler
+        # @param  [Hash] options A hash containing custom options.
+        # @option options [Fixnum] :expires_in The default time after which a
+        #  key should expire.
+        # @option options [Symbol] :adapter Moneta adapter
+        #
+        def using(options = {})
+          merged = Ramaze::Cache::Moneta.trait[:default].merge(options)
+          Class.new(self) { @options = merged }
+        end
+      end # class << self
+
+      ##
+      # Creates a new instance of the cache and merges the options if they
+      # haven't already been set.
+      #
+      # @author Daniel Mendler
+      # @param  [Hash] options A hash with custom options. See
+      #  Ramaze::Cache::Moneta.using() and the trait :default for more
+      #  information.
+      #
+      def initialize(options = {})
+        self.class.options ||=
+          Ramaze::Cache::Moneta.trait[:default].merge(options)
+
+        @options = options.merge(self.class.options)
+      end
+
+      ##
+      # Prepares the cache by setting up the prefix and loading Moneta.
+      #
+      # @author Daniel Mendler
+      #
+      def cache_setup(*args)
+        opts = options.dup
+        opts[:prefix] = ['ramaze', *args].compact.join(':')
+        opts[:expires] = opts.delete(:expires_in)
+        adapter = opts.delete(:adapter)
+        @moneta = ::Moneta.new(adapter, options)
+      end
+
+      ##
+      # Clears the entire cache.
+      #
+      # @author Daniel Mendler
+      #
+      def cache_clear
+        @moneta.clear
+      end
+
+      ##
+      # Removes a number of keys from the cache.
+      #
+      # @author Daniel Mendler
+      # @param  [Array] keys An array of key names to remove.
+      #
+      def cache_delete(*keys)
+        keys.each {|key| @moneta.delete(key) }
+      end
+
+      ##
+      # Retrieves the value of the given key. If no value could be retrieved the
+      # default value (set to nil by default) will be returned instead.
+      #
+      # @author Daniel Mendler
+      # @param  [String] key The name of the key to retrieve.
+      # @param  [Mixed] default The default value.
+      # @return [Mixed]
+      #
+      def cache_fetch(key, default = nil)
+        @moneta.fetch(key, default)
+      end
+
+      ##
+      # Stores a new value under the given key.
+      #
+      # @author Daniel Mendler
+      # @param  [String] key The name of the key to store.
+      # @param  [Mixed] value The value of the key.
+      # @param  [Fixnum] ttl The Time To Live of the key.
+      # @param  [Hash] options A hash containing key specific options.
+      # @option options :expires_in The time after which the key should expire.
+      #
+      def cache_store(key, value, ttl = nil, options = {})
+        options[:expires] = options.delete(:ttl) || @options[:expires_in]
+        @moneta.store(key, value, options)
+      end
+    end # Moneta
+  end # Cache
+end # Ramaze

--- a/ramaze.gemspec
+++ b/ramaze.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rack-contrib'
   s.add_development_dependency 'rack-test'
   s.add_development_dependency 'redis'
+  s.add_development_dependency 'moneta'
   s.add_development_dependency 'sass'
   s.add_development_dependency 'sequel'
   s.add_development_dependency 'slim'

--- a/spec/ramaze/cache/moneta.rb
+++ b/spec/ramaze/cache/moneta.rb
@@ -1,0 +1,53 @@
+require File.expand_path('../../../../spec/helper', __FILE__)
+spec_require 'moneta'
+
+describe Ramaze::Cache::Moneta do
+  Ramaze.options.cache.names   = [:one, :two]
+  Ramaze.options.cache.default = Ramaze::Cache::Moneta
+  Ramaze.setup_dependencies
+
+  cache = Ramaze::Cache.one
+  hello = 'Hello, World!'
+
+  should 'store without ttl' do
+    cache.store(:hello, hello).should == hello
+  end
+
+  should 'fetch' do
+    cache.fetch(:hello).should == hello
+  end
+
+  should 'delete' do
+    cache.delete(:hello)
+    cache.fetch(:hello).should == nil
+  end
+
+  should 'delete two key/value pairs at once' do
+    cache.store(:hello, hello).should == hello
+    cache.store(:ramaze, 'ramaze').should == 'ramaze'
+    cache.delete(:hello, :ramaze)
+    cache.fetch(:hello).should == nil
+    cache.fetch(:innate).should == nil
+  end
+
+  should 'store with ttl' do
+    cache.store(:hello, @hello, :ttl => 1)
+    cache.fetch(:hello).should == @hello
+    sleep 2
+    cache.fetch(:hello).should == nil
+  end
+
+  should 'clear' do
+    cache.store(:hello, @hello)
+    cache.fetch(:hello).should == @hello
+    cache.clear
+    cache.fetch(:hello).should == nil
+  end
+
+  should 'use a custom set of options' do
+    klass = Ramaze::Cache::Moneta.using(:answer => 42)
+
+    klass.options[:answer].should     == 42
+    klass.new.options[:answer].should == 42
+  end
+end


### PR DESCRIPTION
Adds Moneta as a cache backend (http://github.com/minad/moneta). Moneta brings supports for a lot of backends. You might even consider replacing your caching implementation completly with Moneta to avoid code duplication and abstraction nesting (Ramaze cache -> Moneta -> MongoDB/Whatever)

Would be nice to hear from you :)

Daniel
