### PR TITLE
Adds more documentation about flash and flashbox

### DIFF
--- a/guide/general/sessions.md
+++ b/guide/general/sessions.md
@@ -174,9 +174,9 @@ data and the message would no longer be displayed until the client visits
 /set\_message again.
 
 In the above example, the content of the flash is returned by a method in the
-controller. However, the most common scenario is to addres the flash object
-directly in the layouts or viems. You can display flash data (in your layout for
-instance), just line any other variable :
+controller. However, the most common scenario is to address the flash object
+directly in the layouts or viems. You can display flash data (in your
+layout for instance), just like any other variable :
 
     #{flash[:message]}
 


### PR DESCRIPTION
Added documentation on how flash can be used in view or layouts,
explaining that any key can be used.
An example shows how to take advantage of that to use flash keys as css
selectors.
Finally, a small example of how flashbox is used in views is shown.
Hopefully, this fixes #64
