### PR TITLE
Changed :rubygems to https://rubygems.org in Gemfiles

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gemspec

--- a/lib/proto/Gemfile
+++ b/lib/proto/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'ramaze'
 gem 'rake'


### PR DESCRIPTION
... because of the warning "The source :rubygems is deprecated because HTTP requests are insecure" during `bundle install`.
