### PR TITLE
Paginate preserves multi-value parameters

### DIFF
--- a/lib/ramaze/helper/paginate.rb
+++ b/lib/ramaze/helper/paginate.rb
@@ -226,6 +226,11 @@ module Ramaze
 
           action = Current.action
           params = request.params.merge(@var.to_s => n)
+          params.keys.each do |p|
+            if params[p].is_a?(Array) and not p.end_with?('[]')
+              params["#{p}[]"] = params.delete(p)
+            end
+          end
           hash[:href] = action.node.r(action.path, params)
 
           g.a(hash){ text }

--- a/spec/ramaze/helper/paginate.rb
+++ b/spec/ramaze/helper/paginate.rb
@@ -32,6 +32,13 @@ class SpecHelperPaginateArray < Ramaze::Controller
     pager.each{|item| out << item }
     out.inspect
   end
+
+  def preserve_params
+    request.params['single'] = 'zero'
+    request.params['multiple'] = %w[ one two three ]
+    pager = paginate(ALPHA)
+    pager.navigation
+  end
 end
 
 describe Ramaze::Helper::Paginate do
@@ -273,6 +280,24 @@ describe Ramaze::Helper::Paginate do
       last = spans[1][:class]
       last.should == "TheLast Severely Disabled"
 
+    end
+
+    it 'preserves single value params' do
+      doc = Nokogiri::HTML(get("/array/preserve_params").body)
+      params = doc.search("//a").first[:href].split('?').last.split('&')
+      params.should.include 'single=zero'
+      params.should.not.include 'single[]'.escape(:cgi) + '=zero'
+    end
+
+    it 'preserves multi value params' do
+      doc = Nokogiri::HTML(get("/array/preserve_params").body)
+      params = doc.search("//a").first[:href].split('?').last.split('&')
+      params.should.not.include 'multiple=one'
+      params.should.not.include 'multiple=two'
+      params.should.not.include 'multiple=three'
+      params.should.include 'multiple[]'.escape(:cgi) + '=one'
+      params.should.include 'multiple[]'.escape(:cgi) + '=two'
+      params.should.include 'multiple[]'.escape(:cgi) + '=three'
     end
 
   end


### PR DESCRIPTION
When Paginate helper composes its navigation links, it includes request.params so that the next request will get the same parameters, in addition to the selected page number.

Some of these parameters can be an Array, for example if it came from a select multiple:

```
<select name="myselect[]" multiple>
```

But in this case request.params contains the key 'myselect', not 'myselect[]'; and pointing to an Array, not to a String.

When creating its links, Paginate simply merges in the current request.params hash so the multi-value param is named 'myselect'. Because of this, when clicking navigation links, the following request.params['myselect'] won't provide an Array, but a single value.

This change fixes it by ensuring that the name of the parameters whose value is an Array end with '[]'.
