### PR TITLE
Add method to pager so Sequel's eager can be used with pagination

### DIFF
--- a/lib/ramaze/helper/paginate.rb
+++ b/lib/ramaze/helper/paginate.rb
@@ -196,6 +196,7 @@ module Ramaze
         # these methods are actually on the pager, but we def them here for
         # convenience (method_missing in helper is evil and even slower)
         def page_count  ; @pager.page_count  ; end
+        def all         ; @pager.all         ; end
         def each(&block); @pager.each(&block); end
         def first_page? ; @pager.first_page? ; end
         def prev_page   ; @pager.prev_page   ; end
@@ -276,12 +277,14 @@ module Ramaze
             page_count == @page
           end
 
-          def each(&block)
+          def all
             from = ((@page - 1) * @limit)
             to = from + @limit
+            @array[from...to] || []
+          end
 
-            a = @array[from...to] || []
-            a.each(&block)
+          def each(&block)
+            all.each(&block)
           end
 
           include Enumerable

--- a/spec/ramaze/helper/paginate.rb
+++ b/spec/ramaze/helper/paginate.rb
@@ -33,6 +33,11 @@ class SpecHelperPaginateArray < Ramaze::Controller
     out.inspect
   end
 
+  def all
+    pager = paginate(ALPHA)
+    pager.all.inspect
+  end
+
   def preserve_params
     request.params['single'] = 'zero'
     request.params['multiple'] = %w[ one two three ]
@@ -84,6 +89,11 @@ describe Ramaze::Helper::Paginate do
 
     it 'iterates over the items in the pager' do
       got = get('/array/iteration')
+      got.body.scan(/\w+/).should == SpecHelperPaginateArray::ALPHA.first(10)
+    end
+
+    it 'returns all the items in the pager range' do
+      got = get('/array/all')
       got.body.scan(/\w+/).should == SpecHelperPaginateArray::ALPHA.first(10)
     end
 


### PR DESCRIPTION
Sequel can preload all matching associations by using the `eager` method. It will first load the dataset with the given query, and then it will query the database once for each one of the specified associations. For this to work, the query executing method has to be `all`, not the usual `each`, but it can still have pagination parameters as part of the query.

This change provides an `all` method to the pager, that is propagated to Sequel's dataset. It also includes `ArrayPager#all`, that returns the array range, to ensure proper compatibility with plain arrays.

Here is an usage example. It will generate 2 SQL queries, instead of 1 + N:

``` ruby
# controller
@artists = paginate(Artist.eager(:albums))
```

``` html
<!-- view -->
<?r @artists.all.each do |artist| ?>
  #{artist.name}
  <?r artist.albums.each do |album| ?>
    #{album.title}
  <?r end ?>
<?r end ?>
```
